### PR TITLE
Fix: Align user controls to the right in the header

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -324,102 +324,109 @@ const Index = () => {
             <main className="container mx-auto p-4">
                 <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
                     {/* Desktop Navigation */}
-                    <div className="hidden md:flex items-center gap-4 mb-8">
-                        <TabsList className="grid w-full grid-cols-5">
-                            <TabsTrigger value="market" className="flex items-center gap-2">
-                                <BarChart3 className="h-4 w-4" />
-                                Market Board
-                            </TabsTrigger>
-                            <TabsTrigger value="encyclopedia" className="flex items-center gap-2">
-                                <BookOpen className="h-4 w-4" />
-                                Encyclopedia
-                            </TabsTrigger>
-                            <TabsTrigger value="calculator" className="flex items-center gap-2">
-                                <Calculator className="h-4 w-4" />
-                                Calculator
-                            </TabsTrigger>
-                            <TabsTrigger value="system" className="flex items-center gap-2">
-                                <Settings className="h-4 w-4" />
-                                System
-                            </TabsTrigger>
-                            <TabsTrigger value="notifications" className="flex items-center gap-2">
-                                <Bell className="h-4 w-4" />
-                                Notifications
-                            </TabsTrigger>
-                        </TabsList>
-                        <ThemeToggle />
-                        <div className={`status-indicator ${wsStatus === 'connected' ? 'status-online' : 'status-offline'}`}> 
-                            <div className={`w-2 h-2 rounded-full ${wsStatus === 'connected' ? 'bg-green-500' : 'bg-red-500'} ${wsStatus === 'connecting' ? 'pulse-glow' : ''}`} />
-                            {wsStatus === 'connected' ? 'Live' : wsStatus === 'connecting' ? 'Connecting...' : 'Offline'}
+                    <div className="hidden md:flex items-center justify-between gap-4 mb-8">
+                        {/* Main Navigation */}
+                        <div className="flex-grow">
+                            <TabsList className="grid w-full grid-cols-5">
+                                <TabsTrigger value="market" className="flex items-center gap-2">
+                                    <BarChart3 className="h-4 w-4" />
+                                    Market Board
+                                </TabsTrigger>
+                                <TabsTrigger value="encyclopedia" className="flex items-center gap-2">
+                                    <BookOpen className="h-4 w-4" />
+                                    Encyclopedia
+                                </TabsTrigger>
+                                <TabsTrigger value="calculator" className="flex items-center gap-2">
+                                    <Calculator className="h-4 w-4" />
+                                    Calculator
+                                </TabsTrigger>
+                                <TabsTrigger value="system" className="flex items-center gap-2">
+                                    <Settings className="h-4 w-4" />
+                                    System
+                                </TabsTrigger>
+                                <TabsTrigger value="notifications" className="flex items-center gap-2">
+                                    <Bell className="h-4 w-4" />
+                                    Notifications
+                                </TabsTrigger>
+                            </TabsList>
                         </div>
-                        {!loading && (
-                            user && !('isGuest' in user) ? (
-                                <DropdownMenu>
-                                    <DropdownMenuTrigger asChild>
-                                        <Button variant="ghost" size="sm" className="gap-2">
-                                            <div className="flex items-center gap-2">
-                                                <Avatar className="h-6 w-6">
-                                                    <AvatarImage
-                                                        src={user.user_metadata?.avatar_url}
-                                                        alt="Profile"
-                                                    />
-                                                    <AvatarFallback className="text-xs">
-                                                        {(user.user_metadata?.full_name || user.email)?.charAt(0).toUpperCase()}
-                                                    </AvatarFallback>
-                                                </Avatar>
-                                                {user.user_metadata?.full_name || user.email}
-                                            </div>
-                                        </Button>
-                                    </DropdownMenuTrigger>
-                                    <DropdownMenuContent align="end" className="bg-card border-border">
-                                        <Link to="/profile">
-                                            <DropdownMenuItem className="text-foreground hover:bg-accent">
-                                                <User className="h-4 w-4 mr-2" />
-                                                Profile
+
+                        {/* User Controls */}
+                        <div className="flex items-center gap-4">
+                            <ThemeToggle />
+                            <div className={`status-indicator ${wsStatus === 'connected' ? 'status-online' : 'status-offline'}`}>
+                                <div className={`w-2 h-2 rounded-full ${wsStatus === 'connected' ? 'bg-green-500' : 'bg-red-500'} ${wsStatus === 'connecting' ? 'pulse-glow' : ''}`} />
+                                {wsStatus === 'connected' ? 'Live' : wsStatus === 'connecting' ? 'Connecting...' : 'Offline'}
+                            </div>
+                            {!loading && (
+                                user && !('isGuest' in user) ? (
+                                    <DropdownMenu>
+                                        <DropdownMenuTrigger asChild>
+                                            <Button variant="ghost" size="sm" className="gap-2">
+                                                <div className="flex items-center gap-2">
+                                                    <Avatar className="h-6 w-6">
+                                                        <AvatarImage
+                                                            src={user.user_metadata?.avatar_url}
+                                                            alt="Profile"
+                                                        />
+                                                        <AvatarFallback className="text-xs">
+                                                            {(user.user_metadata?.full_name || user.email)?.charAt(0).toUpperCase()}
+                                                        </AvatarFallback>
+                                                    </Avatar>
+                                                    {user.user_metadata?.full_name || user.email}
+                                                </div>
+                                            </Button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent align="end" className="bg-card border-border">
+                                            <Link to="/profile">
+                                                <DropdownMenuItem className="text-foreground hover:bg-accent">
+                                                    <User className="h-4 w-4 mr-2" />
+                                                    Profile
+                                                </DropdownMenuItem>
+                                            </Link>
+                                            {user.user_metadata?.provider_id === "939867069070065714" && (
+                                                <>
+                                                    <DropdownMenuSeparator className="bg-border" />
+                                                    <Link to="/admin">
+                                                        <DropdownMenuItem className="text-foreground hover:bg-accent">
+                                                            <Shield className="h-4 w-4 mr-2" />
+                                                            Admin Panel
+                                                        </DropdownMenuItem>
+                                                    </Link>
+                                                </>
+                                            )}
+                                            <DropdownMenuSeparator className="bg-border" />
+                                            <DropdownMenuItem
+                                                onClick={signOut}
+                                                className="text-foreground hover:bg-accent"
+                                            >
+                                                <LogOut className="h-4 w-4 mr-2" />
+                                                Sign Out
                                             </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                    </DropdownMenu>
+                                ) : user && 'isGuest' in user ? (
+                                    <div className="flex items-center gap-2 text-sm">
+                                        <Avatar className="h-6 w-6">
+                                            <AvatarImage src={user.avatar_url} alt="Guest" />
+                                            <AvatarFallback className="text-xs">G</AvatarFallback>
+                                        </Avatar>
+                                        <span className="text-muted-foreground">Guest_{user.id}</span>
+                                        <Link to="/auth">
+                                            <Button variant="outline" size="sm">
+                                                Sign In
+                                            </Button>
                                         </Link>
-                                        {user.user_metadata?.provider_id === "939867069070065714" && (
-                                            <>
-                                                <DropdownMenuSeparator className="bg-border" />
-                                                <Link to="/admin">
-                                                    <DropdownMenuItem className="text-foreground hover:bg-accent">
-                                                        <Shield className="h-4 w-4 mr-2" />
-                                                        Admin Panel
-                                                    </DropdownMenuItem>
-                                                </Link>
-                                            </>
-                                        )}
-                                        <DropdownMenuSeparator className="bg-border" />
-                                        <DropdownMenuItem
-                                            onClick={signOut}
-                                            className="text-foreground hover:bg-accent"
-                                        >
-                                            <LogOut className="h-4 w-4 mr-2" />
-                                            Sign Out
-                                        </DropdownMenuItem>
-                                    </DropdownMenuContent>
-                                </DropdownMenu>
-                            ) : user && 'isGuest' in user ? (
-                                <div className="flex items-center gap-2 text-sm">
-                                    <Avatar className="h-6 w-6">
-                                        <AvatarImage src={user.avatar_url} alt="Guest" />
-                                        <AvatarFallback className="text-xs">G</AvatarFallback>
-                                    </Avatar>
-                                    <span className="text-muted-foreground">Guest_{user.id}</span>
+                                    </div>
+                                ) : (
                                     <Link to="/auth">
                                         <Button variant="outline" size="sm">
                                             Sign In
                                         </Button>
                                     </Link>
-                                </div>
-                            ) : (
-                                <Link to="/auth">
-                                    <Button variant="outline" size="sm">
-                                        Sign In
-                                    </Button>
-                                </Link>
-                            )
-                        )}
+                                )
+                            )}
+                        </div>
                     </div>
                     {/* Tab Contents */}
                     <TabsContent value="market" className="space-y-6">


### PR DESCRIPTION
The user controls in the header were not correctly aligned to the right, appearing next to the main navigation items. This was caused by a flexbox layout issue.

This commit fixes the layout by:
- Wrapping the main navigation tabs in a flexible container that grows to fill available space.
- Grouping the user controls into a separate container to ensure they are aligned together on the right.