### PR TITLE
fix: resolve white screen issue caused by music dialog

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -82,7 +82,6 @@ const Index = () => {
             setNotifications(marketData.notifications);
         }
     }, [marketData]);
-    const [musicDialogOpen, setMusicDialogOpen] = useState(true);
     const [autoPlayMusic, setAutoPlayMusic] = useState(false);
     const [showPlayer, setShowPlayer] = useState(false);
     const [audioSettings, setAudioSettings] = useState({ volume: 0.7, playbackRate: 1 });
@@ -111,7 +110,7 @@ const Index = () => {
             audioRef.current.pause();
         }
         // eslint-disable-next-line
-    }, [autoPlayMusic, musicDialogOpen]);
+    }, [autoPlayMusic]);
 
     // Keep music playing even if player is hidden, unless user said no
     useEffect(() => {
@@ -131,7 +130,10 @@ const Index = () => {
     return (
         <div className="min-h-screen bg-background">
             {/* Music Consent Dialog */}
-            <Dialog open={musicDialogOpen}>
+            <Dialog>
+                <DialogTrigger asChild>
+                    <Button variant="outline" className="fixed bottom-4 left-4 z-50">Play Music?</Button>
+                </DialogTrigger>
                 <DialogContent
                     aria-labelledby="music-dialog-title"
                     aria-describedby="music-dialog-description"
@@ -151,7 +153,6 @@ const Index = () => {
                             <Button
                                 variant="secondary"
                                 onClick={() => {
-                                    setMusicDialogOpen(false);
                                     setAutoPlayMusic(false);
                                 }}
                                 aria-label="Decline background music"
@@ -162,7 +163,6 @@ const Index = () => {
                         <DialogClose asChild>
                             <Button
                                 onClick={() => {
-                                    setMusicDialogOpen(false);
                                     setAutoPlayMusic(true);
                                 }}
                                 aria-label="Enable background music"


### PR DESCRIPTION
The music consent dialog in the Index page was previously configured to be open by default, which blocked your interaction with the rest of the application and resulted in a white screen. This commit addresses the issue by converting the dialog to be trigger-based, ensuring it only appears upon your action.

Key changes:
- Replaced the `open` prop on the `Dialog` component with a `DialogTrigger` that wraps a button, making the dialog appear only when the button is clicked.
- Removed the `musicDialogOpen` state, as it is no longer necessary for controlling the dialog's visibility.
- Updated the `useEffect` hook for audio playback to remove the dependency on `musicDialogOpen`, simplifying the logic.