### PR TITLE
fix: update maintenance switch UI optimistically

### DIFF
--- a/src/hooks/useMaintenanceMode.tsx
+++ b/src/hooks/useMaintenanceMode.tsx
@@ -114,7 +114,9 @@ export const useMaintenanceMode = () => {
     };
 
     const toggleMaintenance = async (component: keyof MaintenanceSettings) => {
-        await updateSettings({ [component]: !settings[component] });
+        const newSettings = { ...settings, [component]: !settings[component] };
+        setSettings(newSettings);
+        await updateSettings({ [component]: newSettings[component] });
     };
 
     const isInMaintenance = (component: keyof MaintenanceSettings) => {


### PR DESCRIPTION
The maintenance mode switch in the admin panel was not updating its state visually without a page refresh. This was because the component was waiting for a real-time subscription update, which was not instantaneous.

This commit fixes the issue by optimistically updating the local state of the switch, providing immediate visual feedback to you.