### PR TITLE
feat: Allow admin users to bypass maintenance mode

### DIFF
--- a/src/components/MaintenanceOverlay.tsx
+++ b/src/components/MaintenanceOverlay.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import { useMaintenanceMode } from '@/hooks/useMaintenanceMode';
 
 interface MaintenanceOverlayProps {
   componentName: string;
@@ -7,6 +8,12 @@ interface MaintenanceOverlayProps {
 }
 
 export const MaintenanceOverlay = ({ componentName, className = '' }: MaintenanceOverlayProps) => {
+  const { isAdmin, showMaintenanceAsAdmin } = useMaintenanceMode();
+
+  if (isAdmin && !showMaintenanceAsAdmin) {
+    return null;
+  }
+
   return (
     <div className={`relative ${className}`}>
       <div className="absolute inset-0 z-10 backdrop-blur-md bg-background/80 flex items-center justify-center rounded-lg">

--- a/src/hooks/useMaintenanceMode.tsx
+++ b/src/hooks/useMaintenanceMode.tsx
@@ -4,6 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import type { Database } from '@/integrations/supabase/types';
 
 type MaintenanceSettingsRow = Database['public']['Tables']['maintenance_settings']['Row'];
+const ADMIN_DISCORD_ID = "939867069070065714";
 
 export interface MaintenanceSettings {
     market: boolean;
@@ -27,6 +28,9 @@ export const useMaintenanceMode = () => {
     const { user } = useAuth();
     const [settings, setSettings] = useState<MaintenanceSettings>(defaultSettings);
     const [loading, setLoading] = useState(true);
+    const [showMaintenanceAsAdmin, setShowMaintenanceAsAdmin] = useState(false);
+
+    const isAdmin = user?.user_metadata?.provider_id === ADMIN_DISCORD_ID;
 
     // Function to fetch maintenance settings from Supabase
     const fetchMaintenanceSettings = async () => {
@@ -120,6 +124,9 @@ export const useMaintenanceMode = () => {
     };
 
     const isInMaintenance = (component: keyof MaintenanceSettings) => {
+        if (isAdmin && !showMaintenanceAsAdmin) {
+            return false;
+        }
         return settings[component];
     };
 
@@ -129,5 +136,8 @@ export const useMaintenanceMode = () => {
         toggleMaintenance,
         isInMaintenance,
         loading,
+        showMaintenanceAsAdmin,
+        setShowMaintenanceAsAdmin,
+        isAdmin,
     };
 };

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -36,7 +36,13 @@ const ADMIN_DISCORD_ID = "939867069070065714";
 const Admin = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { settings: maintenanceSettings, toggleMaintenance } = useMaintenanceMode();
+  const {
+    settings: maintenanceSettings,
+    toggleMaintenance,
+    showMaintenanceAsAdmin,
+    setShowMaintenanceAsAdmin,
+    isAdmin
+  } = useMaintenanceMode();
   const [users, setUsers] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [showUserManagement, setShowUserManagement] = useState(false);
@@ -1356,6 +1362,23 @@ const Admin = () => {
                 <CardTitle>App Components</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
+                {isAdmin && (
+                  <div className="flex items-center justify-between p-4 rounded-lg border bg-accent/50">
+                    <div className="flex items-center gap-3">
+                      <Shield className="h-5 w-5 text-primary" />
+                      <div>
+                        <p className="font-medium">Admin Bypass</p>
+                        <p className="text-sm text-muted-foreground">
+                          Toggle to view the site as a regular user
+                        </p>
+                      </div>
+                    </div>
+                    <Switch
+                      checked={!showMaintenanceAsAdmin}
+                      onCheckedChange={(checked) => setShowMaintenanceAsAdmin(!checked)}
+                    />
+                  </div>
+                )}
                 {Object.entries(maintenanceSettings).map(([component, isInMaintenance]) => {
                   const componentLabels = {
                     market: { label: 'Market Board', icon: BarChart3, description: 'Stock market data and trading information' },


### PR DESCRIPTION
This commit introduces a feature that allows admin users to bypass the maintenance mode and view the site as a regular user.

The changes include:
- A new state variable in the `useMaintenanceMode` hook to track the admin's preference.
- A toggle switch in the admin panel to enable or disable the bypass.
- Conditional rendering of the `MaintenanceOverlay` component based on the admin's preference.