### PR TITLE
fix: Add user_metadata to GuestUser type

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -7,6 +7,7 @@ interface GuestUser {
     display_name: string;
     avatar_url: string;
     isGuest: true;
+    user_metadata: {};
 }
 
 interface AuthContextType {
@@ -54,7 +55,8 @@ const getOrCreateGuestUser = (): GuestUser => {
         id: guestId,
         display_name: `Guest_${guestId.slice(-6)}`,
         avatar_url: `https://api.dicebear.com/7.x/avataaars/svg?seed=${guestId}`,
-        isGuest: true
+        isGuest: true,
+        user_metadata: {}
     };
     
     console.log('💾 Saving guest user to localStorage:', guestUser);


### PR DESCRIPTION
This commit fixes a TypeScript error that occurred when a guest user was active. The `GuestUser` type was missing the `user_metadata` property, which is present on the Supabase `User` type.

I have added the `user_metadata` property to the `GuestUser` interface and initialized it as an empty object in the `getOrCreateGuestUser` function. This makes the `GuestUser` type compatible with the `User` type, resolving the type error in `useMaintenanceMode.tsx`.