### PR TITLE
fix(admin): remove incorrect type casting for maintenanceSettings

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -448,7 +448,7 @@ const Admin = () => {
                 return (
                     <MaintenanceMode
                         onBack={() => setActiveComponent('dashboard')}
-                        settings={maintenanceSettings as Record<string, boolean>}
+                        settings={maintenanceSettings}
                         showMaintenanceAsAdmin={showMaintenanceAsAdmin}
                         setShowMaintenanceAsAdmin={setShowMaintenanceAsAdmin}
                         isAdmin={isAdmin}
@@ -468,7 +468,7 @@ const Admin = () => {
                             if (section === 'api') fetchApiAnalytics();
                             if (section === 'market') fetchMarketAnalytics();
                         }}
-                        maintenanceSettings={maintenanceSettings as Record<string, boolean>}
+                        maintenanceSettings={maintenanceSettings}
                     />
                 );
         }


### PR DESCRIPTION
The `maintenanceSettings` object is of type `MaintenanceSettings`, but it was being cast to `Record<string, boolean>`. This was causing a TypeScript error because the types are not compatible.

This change removes the incorrect type casting, which resolves the TypeScript error.