### PR TITLE
feat: Use Supabase for weather data

### DIFF
--- a/src/hooks/useWeatherData.tsx
+++ b/src/hooks/useWeatherData.tsx
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/types/database.types';
+
+type Weather = Database['public']['Tables']['weather']['Row'];
+
+export const useWeatherData = () => {
+  const [weatherData, setWeatherData] = useState<Weather[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchWeatherData = async () => {
+      const { data, error } = await supabase.from('weather').select('*');
+      if (error) {
+        setError(error.message);
+      } else {
+        setWeatherData(data as Weather[]);
+      }
+    };
+
+    fetchWeatherData();
+
+    const channel = supabase
+      .channel('weather-changes')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'weather' },
+        (payload) => {
+          fetchWeatherData(); // Refetch all data on change
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, []);
+
+  return { weatherData, error };
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -35,6 +35,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useMaintenanceMode } from '@/hooks/useMaintenanceMode';
 import { useStockData } from '@/hooks/useStockData';
 import { useWebSocketData } from '@/hooks/useWebSocketData';
+import { useWeatherData } from '@/hooks/useWeatherData';
 
 import { MarketBoard } from '@/components/MarketBoard';
 import { WeatherStatus } from '@/components/WeatherStatus';
@@ -74,7 +75,8 @@ const Index = () => {
 
     // Use separate hooks for stock data and weather data
     const { marketData, loading: stockLoading, error: stockError, refetch } = useStockData(userId);
-    const { weatherData, notifications: wsNotifications, travelingMerchantStock, wsStatus } = useWebSocketData(userId);
+    const { weatherData, error: weatherError } = useWeatherData();
+    const { notifications: wsNotifications, travelingMerchantStock, wsStatus } = useWebSocketData(userId);
 
     // Update notifications from API calls or other sources
     useEffect(() => {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -114,6 +114,35 @@ export interface Database {
           created_at?: string;
         };
       };
+      weather: {
+        Row: {
+          weather_id: string;
+          weather_name: string;
+          icon: string;
+          duration: number;
+          active: boolean;
+          start_duration_unix: number;
+          end_duration_unix: number;
+        };
+        Insert: {
+          weather_id: string;
+          weather_name: string;
+          icon: string;
+          duration: number;
+          active: boolean;
+          start_duration_unix: number;
+          end_duration_unix: number;
+        };
+        Update: {
+          weather_id?: string;
+          weather_name?: string;
+          icon?: string;
+          duration?: number;
+          active?: boolean;
+          start_duration_unix?: number;
+          end_duration_unix?: number;
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
- Replaced the WebSocket connection for weather data with a direct Supabase query.
- Created a new `useWeatherData` hook to fetch and subscribe to real-time weather updates from the `weather` table.
- Updated `Index.tsx` to use the new hook.
- Manually updated the database type definitions to include the `weather` table.