### PR TITLE
feat: make weather countdown update in real-time

### DIFF
--- a/src/components/WeatherStatus.tsx
+++ b/src/components/WeatherStatus.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import type { Database } from '@/types/database.types';
@@ -11,6 +12,16 @@ interface WeatherStatusProps {
 }
 
 export const WeatherStatus = ({ weatherData, loading, error }: WeatherStatusProps) => {
+    const [, setNow] = useState(Date.now());
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setNow(Date.now());
+        }, 1000); // Update every second
+
+        return () => clearInterval(interval);
+    }, []);
+
     const activeWeathers = weatherData.filter(w => w.active);
     const forecastWeathers = weatherData.filter(w => !w.active).slice(0, 6);
 


### PR DESCRIPTION
The weather display countdown timer was not updating in real-time, requiring a page refresh to see the latest time remaining. This was because the component was not re-rendering to update the countdown.

This change introduces a `useEffect` hook with a `setInterval` in the `WeatherStatus` component. This forces the component to re-render every second, ensuring the countdown timer is always up-to-date without needing a full page refresh.