### PR TITLE
fix(notifications): Ensure stock alert notifications are created reli…

### DIFF
--- a/src/hooks/useStockData.tsx
+++ b/src/hooks/useStockData.tsx
@@ -219,6 +219,10 @@ export const useStockData = (userId: string | null): StockDataHook => {
                 }
             }
 
+            // This ref must be updated *after* the comparison logic and *before* the state update logic.
+            // This ensures that the next fetch will always compare against the most recent data.
+            prevMarketDataRef.current = transformedData;
+
             // Update if it's initial fetch, data should update based on interval, or data has changed
             if (isInitialFetch || shouldUpdate || hasDataChanged) {
                 if (debug) {
@@ -257,8 +261,6 @@ export const useStockData = (userId: string | null): StockDataHook => {
                     }
                     return transformedData;
                 });
-
-                prevMarketDataRef.current = transformedData;
 
 
                 if (isInitialFetchRef.current) {


### PR DESCRIPTION
…ably

The stock alert notification system was failing to create notifications when an item returned to stock. This was due to a logical flaw in the `useStockData` hook.

The hook uses a `ref` (`prevMarketDataRef`) to store the previous stock data for comparison. However, this `ref` was only being updated if the component's state was also being updated. If the state update was skipped for any reason (e.g., if `lodash.isEqual` returned an unexpected result), the `ref` would become stale.

When the next fetch occurred, the stock comparison logic would use this stale data, causing the `oldStock === 0` check to fail and preventing the notification from being created.

This fix moves the update of `prevMarketDataRef` to occur after every fetch, regardless of whether the component's state is updated. This ensures that the stock alert check always uses the most recent data for comparison, making the notification system reliable.