### PR TITLE
fix(notifications): Ensure stock alert notifications check all item c…

### DIFF
--- a/src/hooks/useStockData.tsx
+++ b/src/hooks/useStockData.tsx
@@ -149,6 +149,9 @@ export const useStockData = (userId: string | null): StockDataHook => {
                     ...prevMarketDataRef.current.seed_stock,
                     ...prevMarketDataRef.current.gear_stock,
                     ...prevMarketDataRef.current.egg_stock,
+                    ...prevMarketDataRef.current.cosmetic_stock,
+                    ...prevMarketDataRef.current.eventshop_stock,
+                    ...prevMarketDataRef.current.travelingmerchant_stock,
                 ];
                 const oldStockMap = new Map(allOldItems.map(item => [item.item_id, item.quantity]));
 
@@ -156,6 +159,9 @@ export const useStockData = (userId: string | null): StockDataHook => {
                     ...transformedData.seed_stock,
                     ...transformedData.gear_stock,
                     ...transformedData.egg_stock,
+                    ...transformedData.cosmetic_stock,
+                    ...transformedData.eventshop_stock,
+                    ...transformedData.travelingmerchant_stock,
                 ];
 
                 if (debug) {


### PR DESCRIPTION
…ategories

The stock alert notification system was failing to create notifications for certain items, such as carrots, when they returned to stock. This was because the notification trigger logic was not comprehensive.

The root cause was that the code responsible for comparing old and new stock levels only checked for items in the `seed_stock`, `gear_stock`, and `egg_stock` categories. It completely ignored items sold in `cosmetic_stock`, `eventshop_stock`, and `travelingmerchant_stock`.

This fix expands the comparison logic to include all stock categories returned by the API. The system will now correctly detect stock changes for any item you are subscribed to, regardless of its category, making the feature reliable.

This also includes a previous commit that improved the update reliability of the reference data used for comparison.