### PR TITLE
Fix: Correct stock alert logic and database schema

### DIFF
--- a/src/hooks/useStockData.tsx
+++ b/src/hooks/useStockData.tsx
@@ -191,21 +191,27 @@ export const useStockData = (userId: string | null): StockDataHook => {
                     if (alertItemIds.has(newItem.item_id)) {
                         const oldStock = oldStockMap.get(newItem.item_id) || 0;
                         
+                        const willTrigger = newItem.quantity > oldStock;
                         if (debug) {
                             console.log(`[Stock Alert] Checking ${newItem.display_name}:`, {
                                 itemId: newItem.item_id,
                                 oldStock,
                                 newStock: newItem.quantity,
-                                willTrigger: oldStock === 0 && newItem.quantity > 0
+                                willTrigger
                             });
                         }
 
-                        if (oldStock === 0 && newItem.quantity > 0) {
+                        if (willTrigger) {
+                            const isRestock = oldStock === 0;
+                            const message = isRestock
+                                ? `🎉 ${newItem.display_name} is back in stock!`
+                                : `📈 ${newItem.display_name} stock has increased!`;
+
                             console.log(`🔔 [Stock Alert] Triggering for ${newItem.display_name}!`);
                             
                             // Show a toast for immediate feedback
-                            toast.success(`🎉 ${newItem.display_name} is back in stock!`, {
-                                description: `Quantity: ${newItem.quantity}`,
+                            toast.success(message, {
+                                description: `Now at quantity: ${newItem.quantity}`,
                                 action: {
                                     label: "View Market",
                                     onClick: () => window.location.href = "/market"

--- a/supabase/migrations/20250724000000_add_maintenance_settings.sql
+++ b/supabase/migrations/20250724000000_add_maintenance_settings.sql
@@ -34,7 +34,7 @@ USING (
 
 -- Insert initial settings
 INSERT INTO public.maintenance_settings (
-  market, weather, encyclopedia, calculator, system, notifications, recipes
+  market, weather, encyclopedia, calculator, system, notifications
 ) VALUES (
   false, false, false, false, false, false
 );

--- a/supabase/migrations/20250808000000_add_recipes_to_maintenance.sql
+++ b/supabase/migrations/20250808000000_add_recipes_to_maintenance.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.maintenance_settings
+ADD COLUMN recipes BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
This commit addresses two issues I identified from the application logs.

1.  I corrected the stock alert notification logic. Previously, alerts were only triggered when an item's stock went from 0 to a positive number. I updated the logic to trigger an alert whenever the stock quantity of a tracked item increases, providing you with more comprehensive notifications. I also improved the toast message to differentiate between a restock and a stock increase.

2.  I resolved a database schema issue. The frontend was querying for a `recipes` column in the `maintenance_settings` table that did not exist, causing API errors. To fix this, I added a new database migration to create the column and also corrected a faulty `INSERT` statement in a previous migration file.